### PR TITLE
Switch image URLs to ImageKit

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,10 +39,9 @@ const s3 = new AWS.S3({
 
 const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
 
-// your resize API
-const RESIZER_API_URL =
-  process.env.REACT_APP_RESIZER_API_URL ||
-  "https://rd654zmm4e.execute-api.us-east-1.amazonaws.com/prod/resize";
+// helper to build an ImageKit transformation URL
+const getResizedUrl = (key, width = 1000) =>
+  `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width}`;
 
 export default function App() {
   const [sessionId, setSessionId] = useState(null);
@@ -78,10 +77,10 @@ export default function App() {
       .listObjectsV2({ Prefix: `${sessionId}/` })
       .promise();
 
-    // map each key into your resizer URL
+    // map each key into the ImageKit URL
     const urls = Contents.map((o) => {
       const key = o.Key; // e.g. "1612345678901/myImage.jpg"
-      return `${RESIZER_API_URL}/${encodeURI(key)}?width=1000`;
+      return getResizedUrl(key, 1000);
     });
 
     setLoadedImages(urls);
@@ -138,10 +137,8 @@ export default function App() {
             <ImageUploader
               sessionId={sessionId}
               onContinue={(finishedUploads) => {
-                const keys = finishedUploads.map((u) => u.key); 
-                const urls = keys.map((k) =>
-                  `${RESIZER_API_URL}/${encodeURI(k)}?width=1000`
-                );
+                const keys = finishedUploads.map((u) => u.key);
+                const urls = keys.map((k) => getResizedUrl(k, 1000));
                 setLoadedImages(urls);
                 setView("editor");
               }}

--- a/src/components/ImageUploader.js
+++ b/src/components/ImageUploader.js
@@ -10,13 +10,10 @@ const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
 const IK_AUTH_ENDPOINT = process.env.REACT_APP_IMAGEKIT_AUTH_ENDPOINT || "";
 const MAX_IMAGES = 100;
 const MIN_IMAGES = 20;     // ← minimum required photos
-const RESIZER_API_URL =
-    process.env.REACT_APP_RESIZER_API_URL ||
-    "https://rd654zmm4e.execute-api.us-east-1.amazonaws.com/prod/resize";
 
-// helper to build a resize URL with cache-busting
+// helper to build a resize URL via ImageKit with cache-busting
 const getResizedUrl = (key, width = 300) =>
-    `${RESIZER_API_URL}/${encodeURIComponent(key)}?width=${width}&cacheBust=${Date.now()}`;
+    `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width}&v=${Date.now()}`;
 
 export default function ImageUploader({ sessionId, onContinue }) {
     const [uploads, setUploads] = useState([]);


### PR DESCRIPTION
## Summary
- switch from custom resizer API to ImageKit transformation URLs
- adjust uploader preview URLs accordingly

## Testing
- `npm test --silent --maxWorkers=50`

------
https://chatgpt.com/codex/tasks/task_e_686975e24bc083238712572c57546f93