### PR TITLE
Fix theme/modal aria-hidden focus issue

### DIFF
--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -242,7 +242,11 @@ export default function EditorPage({ images }) {
     };
 
     // TEMPLATE & THEME MODALS
-    const openTemplateModal = pi => {
+    const openTemplateModal = (pi) => {
+        // blur the active element to avoid accessibility warnings when the Layer opens
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+        }
         setTemplateModalPage(pi);
         setShowTemplateModal(true);
     };
@@ -255,7 +259,11 @@ export default function EditorPage({ images }) {
         setShowTemplateModal(false);
     };
 
-    const openThemeModal = pi => {
+    const openThemeModal = (pi) => {
+        // blur active element so the button losing focus prevents aria-hidden warning
+        if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+        }
         setThemeModalPage(pi);
         setShowThemeModal(true);
     };


### PR DESCRIPTION
## Summary
- avoid `aria-hidden` warning by blurring active toolbar button before opening template or theme modals

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e51df0a488323b50efb7451439a82