### PR TITLE
Fix theme selection and responsive page layout

### DIFF
--- a/src/components/EditorPage.css
+++ b/src/components/EditorPage.css
@@ -25,8 +25,10 @@
 /* photo pages */
 .photo-page {
     position: relative;
-    width: 500px;
-    height: 375px;
+    width: 100%;
+    max-width: 500px;
+    height: 0;
+    padding-top: 75%;
     overflow: hidden;
     touch-action: none;
     /* background-color / background-image will be set inline via React */
@@ -150,6 +152,7 @@
   position: relative;
   margin: 10px;
   width: 100%;
+  max-width: 500px;
 }
 
 .page-wrapper .toolbar {

--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -407,9 +407,7 @@ export default function EditorPage({ images }) {
             {showThemeModal && (
                 <ThemeModal
                     pageIdx={themeModalPage}
-                    onSelect={opts =>
-                        pickTheme(themeModalPage, opts)
-                    }
+                    onSelect={pickTheme}
                     onClose={() => setShowThemeModal(false)}
                 />
             )}


### PR DESCRIPTION
## Summary
- ensure theme modal passes selected options correctly
- make `.photo-page` and `.page-wrapper` responsive to avoid overflow

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686e57e1168483238c59041b83f4c407