### PR TITLE
Improve mobile usability

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -119,10 +119,12 @@ export default function App() {
         <PageContent pad="large">
           {showPrompt && (
             <Layer
+              position="center"
+              responsive={false}
               onEsc={() => setShowPrompt(false)}
               onClickOutside={() => setShowPrompt(false)}
             >
-              <Box pad="medium" gap="small">
+              <Box pad="medium" gap="small" style={{ maxWidth: '90vw' }}>
                 <Text>Continue your previous session?</Text>
                 <Box direction="row" gap="small">
                   <Button label="Continue" primary onClick={continueSession} />

--- a/src/components/EditorPage.css
+++ b/src/components/EditorPage.css
@@ -30,7 +30,8 @@
     height: 0;
     padding-top: 75%;
     overflow: hidden;
-    touch-action: none;
+    /* allow vertical scrolling while still enabling touch drag */
+    touch-action: pan-y;
     /* background-color / background-image will be set inline via React */
 }
 

--- a/src/components/TemplateModal.js
+++ b/src/components/TemplateModal.js
@@ -5,8 +5,13 @@ import { pageTemplates } from '../templates/pageTemplates';
 
 export default function TemplateModal({ onSelect, onClose }) {
     return (
-        <Layer onEsc={onClose} onClickOutside={onClose}>
-            <Box pad="medium" width="medium" gap="small">
+        <Layer
+            position="center"
+            responsive={false}
+            onEsc={onClose}
+            onClickOutside={onClose}
+        >
+            <Box pad="medium" width="medium" gap="small" style={{ maxWidth: '90vw' }}>
                 <Box direction="row" justify="between" align="center">
                     <Text weight="bold">Templates</Text>
                     <Button label="×" onClick={onClose} />

--- a/src/components/ThemeModal.js
+++ b/src/components/ThemeModal.js
@@ -4,8 +4,13 @@ import { themeGroups } from '../templates/predefinedThemes';
 
 export default function ThemeModal({ onSelect, onClose, pageIdx }) {
     return (
-        <Layer onEsc={onClose} onClickOutside={onClose}>
-            <Box pad="small" gap="medium" width="medium">
+        <Layer
+            position="center"
+            responsive={false}
+            onEsc={onClose}
+            onClickOutside={onClose}
+        >
+            <Box pad="small" gap="medium" width="medium" style={{ maxWidth: '90vw' }}>
                 {themeGroups.map(group => (
                     <Box key={group.name}>
                         <Text weight="bold">{group.name}</Text>


### PR DESCRIPTION
## Summary
- allow vertical scrolling over pictures while still supporting touch drag
- center the session prompt modal for improved mobile layout
- center the layout picker modal
- center the color picker modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e5ef94780832381b4b74928c35d99