### PR TITLE
Add global settings bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,7 +145,12 @@ export default function App() {
               }}
             />
           ) : (
-            <EditorPage images={loadedImages} />
+            <EditorPage
+              images={loadedImages}
+              onAddImages={(urls) =>
+                setLoadedImages((prev) => [...prev, ...urls])
+              }
+            />
           )}
         </PageContent>
       </Page>

--- a/src/components/EditorPage.css
+++ b/src/components/EditorPage.css
@@ -181,5 +181,23 @@
 .skeleton-photo-slot {
     background: #e0e0e0;
     flex: 1;
+    border-radius: 4px;    height: 150px; }
+/* floating settings bar */
+.settings-bar {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    z-index: 1000;
     border-radius: 4px;
-    height: 150px; }
+}
+
+@media (max-width: 600px) {
+    .settings-bar {
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: 0;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+}

--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -6,14 +6,17 @@ import { Box, Button } from "grommet";
 import { Template as TemplateIcon, Brush } from "grommet-icons";
 import TemplateModal from "./TemplateModal";
 import ThemeModal from "./ThemeModal";
+import SettingsBar from "./SettingsBar";
 import { pageTemplates } from "../templates/pageTemplates";
 
-export default function EditorPage({ images }) {
+export default function EditorPage({ images, onAddImages }) {
     const [pageSettings, setPageSettings] = useState([]);
     const [showTemplateModal, setShowTemplateModal] = useState(false);
     const [templateModalPage, setTemplateModalPage] = useState(null);
     const [showThemeModal, setShowThemeModal] = useState(false);
     const [themeModalPage, setThemeModalPage] = useState(null);
+    const [borderColor, setBorderColor] = useState('#000000');
+    const [borderEnabled, setBorderEnabled] = useState(true);
 
     // track when all assigned images have been fully preloaded
     const [imagesWarm, setImagesWarm] = useState(false);
@@ -355,9 +358,9 @@ export default function EditorPage({ images }) {
                                             data-page-index={pi}
                                             data-slot-index={slotIdx}
                                             style={{
-                                                borderColor:
-                                                    ps.theme.color ||
-                                                    "transparent",
+                                                border: borderEnabled
+                                                    ? `4px solid ${borderColor}`
+                                                    : 'none'
                                             }}
                                             onMouseDown={e =>
                                                 startDrag(pi, slotIdx, e)
@@ -411,6 +414,14 @@ export default function EditorPage({ images }) {
                     onClose={() => setShowThemeModal(false)}
                 />
             )}
+
+            <SettingsBar
+                borderColor={borderColor}
+                setBorderColor={setBorderColor}
+                borderEnabled={borderEnabled}
+                setBorderEnabled={setBorderEnabled}
+                onAddImages={onAddImages}
+            />
         </>
     );
 }

--- a/src/components/SettingsBar.js
+++ b/src/components/SettingsBar.js
@@ -1,0 +1,40 @@
+import React, { useRef } from 'react';
+import { Box, Button } from 'grommet';
+import { Add } from 'grommet-icons';
+
+export default function SettingsBar({ borderColor, setBorderColor, borderEnabled, setBorderEnabled, onAddImages }) {
+  const fileRef = useRef();
+
+  const handleFiles = (e) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length) {
+      const urls = files.map(f => URL.createObjectURL(f));
+      onAddImages(urls);
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <Box className="settings-bar" direction="row" gap="small" pad="small" background="light-1" elevation="medium" align="center">
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: 'none' }}
+        onChange={handleFiles}
+      />
+      <Button icon={<Add />} label="Add Pictures" onClick={() => fileRef.current && fileRef.current.click()} />
+      <Box direction="row" align="center" gap="xsmall">
+        <input
+          type="color"
+          value={borderColor}
+          disabled={!borderEnabled}
+          onChange={e => setBorderColor(e.target.value)}
+          style={{ width: 32, height: 32, padding: 0, border: 'none', background: 'none' }}
+        />
+        <Button label={borderEnabled ? 'Hide Borders' : 'Show Borders'} onClick={() => setBorderEnabled(!borderEnabled)} />
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- let EditorPage add images and edit global border settings
- add floating SettingsBar component with color picker and toggle
- update EditorPage CSS for responsive settings bar

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f69c8c88323854d10959a81f5d9