### PR TITLE
Add global theme picker and zoom effect

### DIFF
--- a/src/components/EditorPage.css
+++ b/src/components/EditorPage.css
@@ -33,6 +33,11 @@
     /* allow vertical scrolling while still enabling touch drag */
     touch-action: pan-y;
     /* background-color / background-image will be set inline via React */
+    transition: transform 0.3s ease;
+}
+
+.photo-page.zoomed {
+    transform: scale(1.05);
 }
 
 /* your slots */

--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -297,17 +297,18 @@ export default function EditorPage({ images, onAddImages }) {
     };
     const pickTheme = (pi, { mode, color }) => {
         setPageSettings(prev =>
-            prev.map((s, i) =>
-                i === pi
-                    ? {
+            prev.map((s, i) => {
+                if (pi === null || pi === undefined || pi === -1 || i === pi) {
+                    return {
                         ...s,
                         theme: {
                             mode,
                             color: mode === "dynamic" ? null : color,
                         },
-                    }
-                    : s
-            )
+                    };
+                }
+                return s;
+            })
         );
         setShowThemeModal(false);
     };
@@ -374,7 +375,7 @@ export default function EditorPage({ images, onAddImages }) {
                                     />
                                 </Box>
 
-                                <div className="photo-page">
+                                <div className={`photo-page ${!backgroundEnabled ? 'zoomed' : ''}`}>
                                     {tmpl.slots.map((slotPos, slotIdx) => {
                                         const pos = backgroundEnabled
                                             ? slotPositions[slotPos]
@@ -448,6 +449,7 @@ export default function EditorPage({ images, onAddImages }) {
                 backgroundEnabled={backgroundEnabled}
                 setBackgroundEnabled={setBackgroundEnabled}
                 onAddImages={onAddImages}
+                onOpenThemeModal={() => openThemeModal(null)}
             />
         </>
     );

--- a/src/components/SettingsBar.js
+++ b/src/components/SettingsBar.js
@@ -10,6 +10,7 @@ export default function SettingsBar({
   backgroundEnabled,
   setBackgroundEnabled,
   onAddImages,
+  onOpenThemeModal,
 }) {
   const fileRef = useRef();
 
@@ -35,6 +36,9 @@ export default function SettingsBar({
       <Button icon={<Add />} label="Add Pictures" onClick={() => fileRef.current && fileRef.current.click()} />
       <Box direction="row" align="center" gap="xsmall">
         <Button label={backgroundEnabled ? 'Remove Background' : 'Show Background'} onClick={() => setBackgroundEnabled(!backgroundEnabled)} />
+        {onOpenThemeModal && (
+          <Button label="Change Theme" onClick={onOpenThemeModal} />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- allow SettingsBar to open ThemeModal and change theme for all pages
- add zoom animation on photo pages when toggling background

## Testing
- `npm test --silent -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68756bd00ba08323a000e940ece468a8