### PR TITLE
Add download view and ImageKit face focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "express": "^5.1.0",
         "grommet": "^2.46.1",
         "grommet-icons": "^4.12.4",
+        "html-to-image": "^1.11.13",
         "imagekit": "^6.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -9175,6 +9176,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.6.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^5.1.0",
     "grommet": "^2.46.1",
     "grommet-icons": "^4.12.4",
+    "html-to-image": "^1.11.13",
     "imagekit": "^6.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import {
 import { deepMerge } from "grommet/utils";
 import ImageUploader from "./components/ImageUploader";
 import EditorPage from "./components/EditorPage";
+import DownloadPage from "./components/DownloadPage";
 
 // theme
 const theme = deepMerge({
@@ -41,12 +42,13 @@ const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
 
 // helper to build an ImageKit transformation URL
 const getResizedUrl = (key, width = 1000) =>
-  `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width}`;
+  `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width},fo-face`;
 
 export default function App() {
   const [sessionId, setSessionId] = useState(null);
   const [view, setView] = useState("upload");
   const [loadedImages, setLoadedImages] = useState([]);
+  const [albumSettings, setAlbumSettings] = useState(null);
   const [showPrompt, setShowPrompt] = useState(false);
 
   // create-new-session fn (used by the "New Session" button)
@@ -67,6 +69,7 @@ export default function App() {
     localStorage.setItem("sessionId", sid);
     setSessionId(sid);
     setLoadedImages([]);
+    setAlbumSettings(null);
     setView("upload");
     setShowPrompt(false);
   };
@@ -84,6 +87,7 @@ export default function App() {
     });
 
     setLoadedImages(urls);
+    setAlbumSettings(null);
     setView("editor");
     setShowPrompt(false);
   };
@@ -144,12 +148,21 @@ export default function App() {
                 setView("editor");
               }}
             />
-          ) : (
+          ) : view === "editor" ? (
             <EditorPage
               images={loadedImages}
               onAddImages={(urls) =>
                 setLoadedImages((prev) => [...prev, ...urls])
               }
+              onNext={(settings) => {
+                setAlbumSettings(settings);
+                setView("download");
+              }}
+            />
+          ) : (
+            <DownloadPage
+              albumSettings={albumSettings}
+              onBack={() => setView("editor")}
             />
           )}
         </PageContent>

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -1,0 +1,91 @@
+import React, { useRef } from 'react';
+import { Box, Button } from 'grommet';
+import './EditorPage.css';
+import { pageTemplates } from '../templates/pageTemplates';
+import { toJpeg } from 'html-to-image';
+
+const slotMargin = 5;
+const gap = 5;
+const halfWidth = (100 - 2 * slotMargin - gap) / 2;
+const halfHeight = halfWidth;
+const slotPositions = [
+    { top: `${slotMargin}%`, left: `${slotMargin}%`, width: `${halfWidth}%`, height: `${100 - 2 * slotMargin}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin + halfWidth + gap}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin + halfHeight + gap}%`, left: `${slotMargin + halfWidth + gap}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin}%`, width: `${halfWidth}%`, height: `${100 - 2 * slotMargin}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin + halfWidth + gap}%`, width: `${halfWidth}%`, height: `${100 - 2 * slotMargin}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin + halfWidth + gap}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin + halfHeight + gap}%`, left: `${slotMargin}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin + halfHeight + gap}%`, left: `${slotMargin + halfWidth + gap}%`, width: `${halfWidth}%`, height: `${halfHeight}%` },
+    { top: `${slotMargin}%`, left: `${slotMargin}%`, width: `${100 - 2 * slotMargin}%`, height: `${100 - 2 * slotMargin}%` },
+];
+
+export default function DownloadPage({ albumSettings, onBack }) {
+    const refs = useRef([]);
+    const { pageSettings = [], backgroundEnabled = true } = albumSettings || {};
+
+    const handleDownload = (idx) => {
+        const node = refs.current[idx];
+        if (!node) return;
+        toJpeg(node, { quality: 0.95 })
+            .then((dataUrl) => {
+                const link = document.createElement('a');
+                link.download = `page-${idx + 1}.jpeg`;
+                link.href = dataUrl;
+                link.click();
+            })
+            .catch(console.error);
+    };
+
+    const getLarge = (url) => {
+        if (!url) return url;
+        // replace width transformation with 2000px and keep other params
+        return url.replace(/w-\d+/, 'w-2000');
+    };
+
+    return (
+        <Box pad="medium" gap="medium">
+            {pageSettings.map((ps, pi) => {
+                const tmpl = pageTemplates.find(t => t.id === ps.templateId);
+                if (!tmpl) return null;
+                return (
+                    <Box key={pi} gap="small">
+                        <Box
+                            ref={el => refs.current[pi] = el}
+                            className="photo-page"
+                            style={{
+                                position: 'relative',
+                                width: '100%',
+                                maxWidth: '500px',
+                                paddingTop: '75%',
+                                backgroundColor: backgroundEnabled ? (ps.theme.color || 'transparent') : 'transparent'
+                            }}
+                        >
+                            {tmpl.slots.map((slotPos, slotIdx) => (
+                                <Box
+                                    key={slotPos}
+                                    className={`photo-slot slot${slotPos + 1}`}
+                                    style={{
+                                        position: 'absolute',
+                                        overflow: 'hidden',
+                                        borderRadius: '4px',
+                                        ...slotPositions[slotPos]
+                                    }}
+                                >
+                                    <img
+                                        src={getLarge(ps.assignedImages[slotIdx])}
+                                        alt=""
+                                        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                                    />
+                                </Box>
+                            ))}
+                        </Box>
+                        <Button label="Download Page" onClick={() => handleDownload(pi)} />
+                    </Box>
+                );
+            })}
+            <Button label="Back" onClick={onBack} />
+        </Box>
+    );
+}

--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -39,7 +39,7 @@ const slotPositionsNoBg = [
     { top: '0%', left: '0%', width: '100%', height: '100%' },
 ];
 
-export default function EditorPage({ images, onAddImages }) {
+export default function EditorPage({ images, onAddImages, onNext }) {
     const [pageSettings, setPageSettings] = useState([]);
     const [showTemplateModal, setShowTemplateModal] = useState(false);
     const [templateModalPage, setTemplateModalPage] = useState(null);
@@ -454,6 +454,7 @@ export default function EditorPage({ images, onAddImages }) {
                 setBackgroundEnabled={setBackgroundEnabled}
                 onAddImages={onAddImages}
                 onOpenThemeModal={() => openThemeModal(null)}
+                onNext={() => onNext && onNext({ pageSettings, backgroundEnabled })}
             />
         </>
     );

--- a/src/components/ImageUploader.js
+++ b/src/components/ImageUploader.js
@@ -16,7 +16,7 @@ const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
 
 // helper to build a resize URL via ImageKit with cache-busting
 const getResizedUrl = (key, width = 300) =>
-    `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width}&v=${Date.now()}`;
+    `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width},fo-face&v=${Date.now()}`;
 
 export default function ImageUploader({ sessionId, onContinue }) {
     const [uploads, setUploads] = useState([]);

--- a/src/components/SettingsBar.js
+++ b/src/components/SettingsBar.js
@@ -11,6 +11,7 @@ export default function SettingsBar({
   setBackgroundEnabled,
   onAddImages,
   onOpenThemeModal,
+  onNext,
 }) {
   const fileRef = useRef();
 
@@ -38,6 +39,9 @@ export default function SettingsBar({
         <Button label={backgroundEnabled ? 'Remove Background' : 'Show Background'} onClick={() => setBackgroundEnabled(!backgroundEnabled)} />
         {onOpenThemeModal && (
           <Button label="Change Theme" onClick={onOpenThemeModal} />
+        )}
+        {onNext && (
+          <Button primary label="Next" onClick={onNext} />
         )}
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- add ImageKit face centering to uploaded images
- enable exporting album pages
- add next button to go from editing to download view
- create download page component
- include `html-to-image` dependency

## Testing
- `npm run build`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68757e0a9eb88323a3cc09abada03388