### PR TITLE
Add title page and simplify download

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import {
 } from "grommet";
 import { deepMerge } from "grommet/utils";
 import ImageUploader from "./components/ImageUploader";
+import TitlePage from "./components/TitlePage";
 import EditorPage from "./components/EditorPage";
 import DownloadPage from "./components/DownloadPage";
 
@@ -50,6 +51,8 @@ export default function App() {
   const [loadedImages, setLoadedImages] = useState([]);
   const [albumSettings, setAlbumSettings] = useState(null);
   const [showPrompt, setShowPrompt] = useState(false);
+  const [title, setTitle] = useState("");
+  const [subtitle, setSubtitle] = useState("");
 
   // create-new-session fn (used by the "New Session" button)
   const createNewSession = async () => {
@@ -70,6 +73,8 @@ export default function App() {
     setSessionId(sid);
     setLoadedImages([]);
     setAlbumSettings(null);
+    setTitle("");
+    setSubtitle("");
     setView("upload");
     setShowPrompt(false);
   };
@@ -88,6 +93,8 @@ export default function App() {
 
     setLoadedImages(urls);
     setAlbumSettings(null);
+    setTitle("");
+    setSubtitle("");
     setView("editor");
     setShowPrompt(false);
   };
@@ -145,6 +152,14 @@ export default function App() {
                 const keys = finishedUploads.map((u) => u.key);
                 const urls = keys.map((k) => getResizedUrl(k, 1000));
                 setLoadedImages(urls);
+                setView("title");
+              }}
+            />
+          ) : view === "title" ? (
+            <TitlePage
+              onContinue={({ title: t, subtitle: s }) => {
+                setTitle(t);
+                setSubtitle(s);
                 setView("editor");
               }}
             />
@@ -162,6 +177,8 @@ export default function App() {
           ) : (
             <DownloadPage
               albumSettings={albumSettings}
+              title={title}
+              subtitle={subtitle}
               onBack={() => setView("editor")}
             />
           )}

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Box, Button } from 'grommet';
+import { Box, Button, Text } from 'grommet';
 import './EditorPage.css';
 import { pageTemplates } from '../templates/pageTemplates';
 import { toJpeg } from 'html-to-image';
@@ -21,7 +21,7 @@ const slotPositions = [
     { top: `${slotMargin}%`, left: `${slotMargin}%`, width: `${100 - 2 * slotMargin}%`, height: `${100 - 2 * slotMargin}%` },
 ];
 
-export default function DownloadPage({ albumSettings, onBack }) {
+export default function DownloadPage({ albumSettings, title, subtitle, onBack }) {
     const refs = useRef([]);
     const { pageSettings = [], backgroundEnabled = true } = albumSettings || {};
 
@@ -36,6 +36,10 @@ export default function DownloadPage({ albumSettings, onBack }) {
                 link.click();
             })
             .catch(console.error);
+    };
+
+    const handleDownloadAll = () => {
+        pageSettings.forEach((_, idx) => handleDownload(idx));
     };
 
     const getLarge = (url) => {
@@ -62,6 +66,24 @@ export default function DownloadPage({ albumSettings, onBack }) {
                                 backgroundColor: backgroundEnabled ? (ps.theme.color || 'transparent') : 'transparent'
                             }}
                         >
+                            {pi === 0 && (
+                                <Box
+                                    style={{
+                                        position: 'absolute',
+                                        top: '5%',
+                                        left: '50%',
+                                        transform: 'translateX(-50%)',
+                                        textAlign: 'center',
+                                        color: 'white',
+                                        zIndex: 1,
+                                    }}
+                                >
+                                    <Text weight="bold" size="xxlarge">
+                                        {title}
+                                    </Text>
+                                    <Text size="large">{subtitle}</Text>
+                                </Box>
+                            )}
                             {tmpl.slots.map((slotPos, slotIdx) => (
                                 <Box
                                     key={slotPos}
@@ -81,10 +103,10 @@ export default function DownloadPage({ albumSettings, onBack }) {
                                 </Box>
                             ))}
                         </Box>
-                        <Button label="Download Page" onClick={() => handleDownload(pi)} />
                     </Box>
                 );
             })}
+            <Button primary label="Download Album" onClick={handleDownloadAll} />
             <Button label="Back" onClick={onBack} />
         </Box>
     );

--- a/src/components/TitlePage.js
+++ b/src/components/TitlePage.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Box, Heading, TextInput, Button } from 'grommet';
+
+export default function TitlePage({ onContinue }) {
+  const [title, setTitle] = useState('');
+  const [subtitle, setSubtitle] = useState('');
+
+  return (
+    <Box pad="medium" gap="medium" align="start">
+      <Heading level={2} size="xlarge" margin="none">
+        Album Details
+      </Heading>
+      <Box gap="small" width="medium">
+        <TextInput
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <TextInput
+          placeholder="Subtitle"
+          value={subtitle}
+          onChange={(e) => setSubtitle(e.target.value)}
+        />
+        <Button
+          primary
+          label="Continue"
+          onClick={() => onContinue({ title, subtitle })}
+        />
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- create TitlePage component to capture album title & subtitle
- show the title details page after uploading images
- display title and subtitle on first page of downloads
- replace per-page download buttons with single "Download Album" button

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68758792e7e08323bc2ea94fe0478379