### PR TITLE
Add EditorPage design and download popup

### DIFF
--- a/designer/EditorPage.json
+++ b/designer/EditorPage.json
@@ -1,0 +1,39 @@
+{
+  "name": "editor-page",
+  "theme": "grommet",
+  "screens": {
+    "1": {
+      "id": 1,
+      "name": "Editor",
+      "root": 2,
+      "path": "/"
+    }
+  },
+  "screenOrder": [1],
+  "components": {
+    "2": {
+      "id": 2,
+      "type": "grommet.Page",
+      "props": {},
+      "children": [3]
+    },
+    "3": {
+      "id": 3,
+      "type": "grommet.PageContent",
+      "props": {},
+      "children": [4]
+    },
+    "4": {
+      "id": 4,
+      "type": "components.EditorPage",
+      "props": {}
+    }
+  },
+  "nextId": 5,
+  "date": "2025-07-20T00:00:00.000Z",
+  "created": "2025-07-20T00:00:00.000Z",
+  "imports": [
+    { "name": "EditorPage", "path": "../src/components/EditorPage" }
+  ],
+  "version": 3.7
+}

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Box, Button, Text } from 'grommet';
+import { Box, Button, Text, Layer } from 'grommet';
 import { jsPDF } from 'jspdf';
 import './EditorPage.css';
 import { pageTemplates } from '../templates/pageTemplates';
@@ -32,10 +32,12 @@ export default function DownloadPage({ albumSettings, title, subtitle, onBack })
     const refs = useRef([]);
     const { pageSettings = [], backgroundEnabled = true } = albumSettings || {};
     const [selectedSize, setSelectedSize] = useState(null);
+    const [showDownloadMessage, setShowDownloadMessage] = useState(false);
     const paddingPercent = selectedSize ? (selectedSize.height / selectedSize.width) * 100 : 75;
 
     const handleDownloadAll = async () => {
         if (!selectedSize) return;
+        setShowDownloadMessage(true);
         const { width, height } = selectedSize;
         const orientation = width >= height ? 'landscape' : 'portrait';
         const pdf = new jsPDF({ orientation, unit: 'cm', format: [width, height] });
@@ -50,6 +52,7 @@ export default function DownloadPage({ albumSettings, title, subtitle, onBack })
         }
 
         pdf.save('album.pdf');
+        setShowDownloadMessage(false);
     };
 
     const getLarge = (url) => {
@@ -132,6 +135,13 @@ export default function DownloadPage({ albumSettings, title, subtitle, onBack })
             </Box>
             <Button primary label="Download Album" onClick={handleDownloadAll} />
             <Button label="Back" onClick={onBack} />
+            {showDownloadMessage && (
+                <Layer position="center" responsive={false} modal>
+                    <Box pad="medium">
+                        <Text>Your download will start shortly...</Text>
+                    </Box>
+                </Layer>
+            )}
         </Box>
     );
 }


### PR DESCRIPTION
## Summary
- add a Grommet Designer file for `EditorPage`
- show a message before downloading the PDF

## Testing
- `npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687cd8e15f548323b041a06322fff367