### PR TITLE
Fix ESLint unused vars

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,8 +50,6 @@ export default function App() {
   const [view, setView] = useState("size");
   const [loadedImages, setLoadedImages] = useState([]);
   const [showPrompt, setShowPrompt] = useState(false);
-  const [title, setTitle] = useState("");
-  const [subtitle, setSubtitle] = useState("");
   const [albumSize, setAlbumSize] = useState(null);
 
   useEffect(() => {
@@ -79,8 +77,6 @@ export default function App() {
     localStorage.removeItem("albumSize");
     setSessionId(sid);
     setLoadedImages([]);
-    setTitle("");
-    setSubtitle("");
     setAlbumSize(null);
     setView("size");
     setShowPrompt(false);
@@ -99,8 +95,6 @@ export default function App() {
     });
 
     setLoadedImages(urls);
-    setTitle("");
-    setSubtitle("");
     const storedSize = localStorage.getItem("albumSize");
     if (storedSize) {
       setAlbumSize(JSON.parse(storedSize));
@@ -177,13 +171,7 @@ export default function App() {
               }}
             />
           ) : view === "title" ? (
-            <TitlePage
-              onContinue={({ title: t, subtitle: s }) => {
-                setTitle(t);
-                setSubtitle(s);
-                setView("editor");
-              }}
-            />
+            <TitlePage onContinue={() => setView("editor")} />
           ) : view === "editor" ? (
             <EditorPage
               images={loadedImages}


### PR DESCRIPTION
## Summary
- remove unused `title` and `subtitle` state from `src/App.js`
- simplify `TitlePage` handler after removing those variables

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ff0b7dd34832396eef9835fcd95e2