### PR TITLE
Add products page and profile menu

### DIFF
--- a/src/AlbumsPage.js
+++ b/src/AlbumsPage.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { Box, Text } from "grommet";
+
+export default function AlbumsPage() {
+  return (
+    <Box pad="large">
+      <Text>My Albums feature coming soon.</Text>
+    </Box>
+  );
+}

--- a/src/App.js
+++ b/src/App.js
@@ -9,12 +9,13 @@ import {
   Button,
   Layer,
   Box,
+  Menu,
 } from "grommet";
 import { deepMerge } from "grommet/utils";
 import ImageUploader from "./components/ImageUploader";
-import TitlePage from "./components/TitlePage";
 import EditorPage from "./components/EditorPage";
-import ProductDetailPage from "./components/ProductDetailPage";
+import ProductsPage from "./ProductsPage";
+import AlbumsPage from "./AlbumsPage";
 import LoginPage from "./LoginPage";
 import ProfilePage from "./ProfilePage";
 
@@ -58,7 +59,7 @@ export default function App() {
   const handleLogin = (u) => {
     setUser(u);
     localStorage.setItem("user", JSON.stringify(u));
-    setView("size");
+    setView("products");
   };
 
   const handleLogout = () => {
@@ -93,7 +94,7 @@ export default function App() {
     setSessionId(sid);
     setLoadedImages([]);
     setAlbumSize(null);
-    setView("size");
+    setView("products");
     setShowPrompt(false);
   };
 
@@ -115,7 +116,7 @@ export default function App() {
       setAlbumSize(JSON.parse(storedSize));
       setView("editor");
     } else {
-      setView("size");
+      setView("products");
     }
     setShowPrompt(false);
   };
@@ -125,7 +126,7 @@ export default function App() {
     const storedUser = localStorage.getItem("user");
     if (storedUser) {
       setUser(JSON.parse(storedUser));
-      setView("size");
+      setView("products");
     } else {
       setView("login");
       return;
@@ -164,11 +165,18 @@ export default function App() {
       <Page>
         <Header background="brand" pad="small">
           <Text size="large">FlipSnip</Text>
-          <Button
-            label={user ? "Profile" : "Login"}
-            onClick={() => setView(user ? "profile" : "login")}
-          />
-          {user && <Button label="Logout" onClick={handleLogout} />}
+          {user ? (
+            <Menu
+              label="Profile"
+              items={[
+                { label: "My Profile", onClick: () => setView("profile") },
+                { label: "My Albums", onClick: () => setView("albums") },
+                { label: "Sign Out", onClick: handleLogout },
+              ]}
+            />
+          ) : (
+            <Button label="Login" onClick={() => setView("login")} />
+          )}
         </Header>
         <PageContent pad="large">
           {showPrompt && (
@@ -190,13 +198,10 @@ export default function App() {
 
           {view === "profile" ? (
             <ProfilePage user={user} />
-          ) : view === "size" ? (
-            <ProductDetailPage
-              onContinue={(size) => {
-                setAlbumSize(size);
-                setView("upload");
-              }}
-            />
+          ) : view === "albums" ? (
+            <AlbumsPage />
+          ) : view === "products" ? (
+            <ProductsPage onSelect={() => setView("upload")} />
           ) : view === "upload" ? (
             <ImageUploader
               sessionId={sessionId}
@@ -204,11 +209,9 @@ export default function App() {
                 const keys = finishedUploads.map((u) => u.key);
                 const urls = keys.map((k) => getResizedUrl(k, 1000));
                 setLoadedImages(urls);
-                setView("title");
+                setView("editor");
               }}
             />
-          ) : view === "title" ? (
-            <TitlePage onContinue={() => setView("editor")} />
           ) : view === "editor" ? (
             <EditorPage
               images={loadedImages}

--- a/src/ProductsPage.js
+++ b/src/ProductsPage.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Box, Image, Text } from "grommet";
+
+const products = [
+  { id: 1, title: "Soft Cover Album", price: "10 EUR", image: "boy_reading.png" },
+  { id: 2, title: "Hard Cover Album", price: "15 EUR", image: "girl_reading.png" },
+  { id: 3, title: "Premium Album", price: "25 EUR", image: "old_man_reading.png" },
+];
+
+export default function ProductsPage({ onSelect }) {
+  return (
+    <Box direction="row" gap="medium" wrap>
+      {products.map((p) => (
+        <Box
+          key={p.id}
+          width="small"
+          pad="small"
+          round="small"
+          border
+          onClick={() => onSelect(p)}
+          hoverIndicator
+        >
+          <Image src={p.image} alt="" fit="cover" />
+          <Text weight="bold">{p.title}</Text>
+          <Text>{p.price}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple products listing page
- create placeholder albums page
- streamline app flow to use new products page
- combine profile and logout into a menu

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a02b961f083238e8248f73f1c4dfe