### PR TITLE
Add album open feature

### DIFF
--- a/src/AlbumsPage.js
+++ b/src/AlbumsPage.js
@@ -10,7 +10,7 @@ const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
 const getResizedUrl = (key, width = 300) =>
   `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width},fo-face`;
 
-export default function AlbumsPage({ sessionId }) {
+export default function AlbumsPage({ sessionId, onOpen }) {
   const [firstImage, setFirstImage] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -52,7 +52,12 @@ export default function AlbumsPage({ sessionId }) {
       </Text>
       {loading && <Text>Loading...</Text>}
       {!loading && firstImage && (
-        <Box height="small" width="small">
+        <Box
+          height="small"
+          width="small"
+          onClick={() => onOpen && onOpen()}
+          style={{ cursor: onOpen ? "pointer" : undefined }}
+        >
           <Image src={firstImage} fit="cover" />
         </Box>
       )}

--- a/src/App.js
+++ b/src/App.js
@@ -290,7 +290,7 @@ export default function App() {
           {view === "profile" ? (
             <ProfilePage user={user} />
           ) : view === "albums" ? (
-            <AlbumsPage sessionId={sessionId} />
+            <AlbumsPage sessionId={sessionId} onOpen={continueSession} />
           ) : view === "products" ? (
             <ProductsPage onSelect={(p) => { setSelectedProduct(p); setView("productDetail"); }} />
           ) : view === "productDetail" ? (


### PR DESCRIPTION
## Summary
- allow album preview page to open editor when clicked
- pass continue session logic through `onOpen` prop

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688b7b5faf78832387ca7c3c7180b4e2