### PR TITLE
Add album title entry and editing flow

### DIFF
--- a/src/components/EditorPage.css
+++ b/src/components/EditorPage.css
@@ -45,6 +45,26 @@
     transform: scale(1.05);
 }
 
+.title-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: #fff;
+    text-shadow: 0 0 5px rgba(0, 0, 0, 0.7);
+}
+
+.title-overlay h1 {
+    margin: 0;
+    font-size: 2em;
+}
+
+.title-overlay h2 {
+    margin: 0;
+    font-size: 1.2em;
+}
+
 /* your slots */
 .photo-slot {
     position: absolute;

--- a/src/components/SettingsBar.js
+++ b/src/components/SettingsBar.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { Box, Button } from 'grommet';
+import { Edit } from 'grommet-icons';
 //import { Add } from 'grommet-icons';
 
 export default function SettingsBar({
@@ -9,10 +10,11 @@ export default function SettingsBar({
   setBorderEnabled,
   backgroundEnabled,
   setBackgroundEnabled,
-  onAddImages,
-  onOpenThemeModal,
-  onSave,
-}) {
+    onAddImages,
+    onOpenThemeModal,
+    onSave,
+    onEditTitle,
+  }) {
 const BackgroundIcon = () => (
   <svg
     viewBox="0 0 256 256"
@@ -96,12 +98,15 @@ const SavingIcon = () => (
 
           
 
-        {onOpenThemeModal && (
-          <Button className="btn-setting" icon={<ThemeIcon />} label="Change Theme" onClick={onOpenThemeModal} />
-        )}
-        {onSave && (
-          <Button className="btn-setting" icon={<SavingIcon />} label="Save" onClick={onSave} />
-        )}
+          {onOpenThemeModal && (
+            <Button className="btn-setting" icon={<ThemeIcon />} label="Change Theme" onClick={onOpenThemeModal} />
+          )}
+          {onEditTitle && (
+            <Button className="btn-setting" icon={<Edit />} label="Edit Title" onClick={onEditTitle} />
+          )}
+          {onSave && (
+            <Button className="btn-setting" icon={<SavingIcon />} label="Save" onClick={onSave} />
+          )}
      
     </Box>
   );

--- a/src/components/TitleModal.js
+++ b/src/components/TitleModal.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Layer, Box, Heading, TextInput, Button } from 'grommet';
+
+export default function TitleModal({ title: initialTitle = '', subtitle: initialSubtitle = '', onSave, onClose }) {
+  const [title, setTitle] = useState(initialTitle);
+  const [subtitle, setSubtitle] = useState(initialSubtitle);
+
+  return (
+    <Layer position="center" responsive={false} onEsc={onClose} onClickOutside={onClose}>
+      <Box pad="medium" gap="small" width="medium">
+        <Heading level={3} margin="none">Edit Album Details</Heading>
+        <TextInput
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <TextInput
+          placeholder="Subtitle"
+          value={subtitle}
+          onChange={(e) => setSubtitle(e.target.value)}
+        />
+        <Box direction="row" gap="small" justify="end" margin={{ top: 'medium' }}>
+          <Button label="Cancel" onClick={onClose} />
+          <Button primary label="Save" onClick={() => onSave({ title, subtitle })} />
+        </Box>
+      </Box>
+    </Layer>
+  );
+}

--- a/src/components/TitlePage.js
+++ b/src/components/TitlePage.js
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Box, Heading, TextInput, Button } from 'grommet';
 
-export default function TitlePage({ onContinue }) {
-  const [title, setTitle] = useState('');
-  const [subtitle, setSubtitle] = useState('');
+export default function TitlePage({ onContinue, initialTitle = '', initialSubtitle = '' }) {
+  const [title, setTitle] = useState(initialTitle);
+  const [subtitle, setSubtitle] = useState(initialSubtitle);
 
   return (
     <Box pad="medium" gap="medium" align="start">


### PR DESCRIPTION
## Summary
- add title/subtitle step before editor and persist in session
- allow editing album title from settings bar
- overlay title and subtitle on first editor page with full-bleed template

## Testing
- `CI=true yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68adb556150c8323a789dcf45406c262