### PR TITLE
Fix image upload and template placeholder handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -507,8 +507,11 @@ export default function App() {
           ) : view === "editor" ? (
             <EditorPage
               images={loadedImages}
-              onAddImages={(urls) =>
-                setLoadedImages((prev) => [...prev, ...urls])
+              onAddImages={(urls = []) =>
+                setLoadedImages((prev) => [
+                  ...prev,
+                  ...(Array.isArray(urls) ? urls : [urls]),
+                ])
               }
               albumSize={albumSize}
               s3={s3}

--- a/src/components/SettingsBar.js
+++ b/src/components/SettingsBar.js
@@ -10,11 +10,12 @@ export default function SettingsBar({
   setBorderEnabled,
   backgroundEnabled,
   setBackgroundEnabled,
-    onAddImages,
-    onOpenThemeModal,
-    onSave,
-    onEditTitle,
-  }) {
+  onAddImages,
+  onOpenThemeModal,
+  onSave,
+  onEditTitle,
+  fileInputRef,
+}) {
 const BackgroundIcon = () => (
   <svg
     viewBox="0 0 256 256"
@@ -66,13 +67,16 @@ const SavingIcon = () => (
 
 
 
-  const fileRef = useRef();
+  const internalRef = useRef();
+  const fileRef = fileInputRef || internalRef;
 
   const handleFiles = (e) => {
     const files = Array.from(e.target.files || []);
     if (files.length) {
       const urls = files.map(f => URL.createObjectURL(f));
-      onAddImages(urls);
+      if (typeof onAddImages === 'function') {
+        onAddImages(urls);
+      }
       e.target.value = '';
     }
   };


### PR DESCRIPTION
## Summary
- Prevent `url not iterable` errors by guarding image additions and exposing upload input to placeholders
- Pad templates with blank slots and avoid duplicate images in a single page
- Make adding photos resilient and allow placeholders to trigger the file picker

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1449c105483238a56726003dabf9c