### PR TITLE
Fix template slot uploads

### DIFF
--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -1016,6 +1016,11 @@ export default function EditorPage(props) {
                         onAddImagesProp(urls);
                     }
 
+                    // If a specific slot triggered the upload, defer pageSettings
+                    // mutation to the pendingUploadTarget effect. Otherwise append
+                    // new images to the first page (creating it if needed).
+                    if (pendingUploadTarget) return;
+
                     setPageSettings((prev) => {
                         const next = [...prev];
                         // Append to first page or create the first page


### PR DESCRIPTION
## Summary
- Avoid auto-adding uploaded images to the first page when a slot-specific `+` button triggers the file picker
- Defer pageSettings updates to ensure the new photo appears in the clicked template slot immediately

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c14d2d5dc48323922c1319441b4f57