### PR TITLE
Preserve session settings when updating

### DIFF
--- a/netlify/functions/session.js
+++ b/netlify/functions/session.js
@@ -24,7 +24,9 @@ exports.handler = async (event) => {
         `INSERT INTO sessions (user_id, session_id, settings)
          VALUES ($1, $2, $3)
          ON CONFLICT (user_id)
-         DO UPDATE SET session_id = EXCLUDED.session_id, settings = EXCLUDED.settings, updated_at = NOW()`,
+         DO UPDATE SET session_id = EXCLUDED.session_id,
+                       settings = COALESCE(sessions.settings, '{}'::jsonb) || EXCLUDED.settings,
+                       updated_at = NOW()`,
         [userId, sessionId, settings || {}]
       );
       return { statusCode: 200, body: JSON.stringify({ ok: true }) };


### PR DESCRIPTION
## Summary
- keep existing session settings when updating so page assignments persist

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c157b5528c83239e58cd6ba0bd9783