### PR TITLE
feat: add custom background image support

### DIFF
--- a/src/components/EditorPage.js
+++ b/src/components/EditorPage.js
@@ -277,7 +277,7 @@ export default function EditorPage(props) {
 
             pages.push({
                 templateId: tmpl.id,
-                theme: { mode: "dynamic", color: null },
+                theme: { mode: "dynamic", color: null, image: null },
                 assignedImages: assigned,
                 edits: new Array(slotsCount).fill(null),
             });
@@ -318,7 +318,7 @@ export default function EditorPage(props) {
                     setPageSettings((prev) => {
                         if (prev[idx].theme.color === rgb) return prev;
                         const next = [...prev];
-                        next[idx] = { ...next[idx], theme: { mode: "dynamic", color: rgb } };
+                        next[idx] = { ...next[idx], theme: { mode: "dynamic", color: rgb, image: null } };
                         return next;
                     });
                 };
@@ -615,11 +615,18 @@ export default function EditorPage(props) {
         setShowThemeModal(true);
     };
 
-    const pickTheme = (pi, { mode, color }) => {
+    const pickTheme = (pi, { mode, color, image }) => {
         setPageSettings((prev) =>
             prev.map((s, i) => {
                 if (pi === null || pi === undefined || pi === -1 || i === pi) {
-                    return { ...s, theme: { mode, color: mode === "dynamic" ? null : color } };
+                    return {
+                        ...s,
+                        theme: {
+                            mode,
+                            color: mode === "dynamic" ? null : color,
+                            image: mode === "image" ? image : null,
+                        },
+                    };
                 }
                 return s;
             })
@@ -789,9 +796,16 @@ export default function EditorPage(props) {
                                 const tmpl = pageTemplates.find((t) => t.id === ps.templateId);
                                 if (!tmpl) return null;
                                 const bgColor = ps.theme.color || "transparent";
+                                const wrapperStyle = ps.theme.image
+                                    ? {
+                                          backgroundImage: `url(${ps.theme.image})`,
+                                          backgroundSize: "cover",
+                                          backgroundPosition: "center",
+                                      }
+                                    : { backgroundColor: bgColor };
 
                                 return (
-                                    <div key={pi} className="page-wrapper" style={{ backgroundColor: bgColor }}>
+                                    <div key={pi} className="page-wrapper" style={wrapperStyle}>
                                         <Box className="toolbar" direction="row" gap="small" align="center">
                                             {pi !== 0 && (
                                                 <Button
@@ -949,7 +963,13 @@ export default function EditorPage(props) {
                                     width: "100%",
                                     maxWidth: "400px",
                                     paddingTop: `${paddingPercent}%`,
-                                    backgroundColor: ps.theme.color || "transparent",
+                                    ...(ps.theme.image
+                                        ? {
+                                              backgroundImage: `url(${ps.theme.image})`,
+                                              backgroundSize: "cover",
+                                              backgroundPosition: "center",
+                                          }
+                                        : { backgroundColor: ps.theme.color || "transparent" }),
                                     overflow: "hidden",
                                     borderRadius: "12px",
                                 }}
@@ -1012,7 +1032,13 @@ export default function EditorPage(props) {
                 />
             )}
             {showThemeModal && (
-                <ThemeModal pageIdx={themeModalPage} onSelect={pickTheme} onClose={() => setShowThemeModal(false)} />
+                <ThemeModal
+                    pageIdx={themeModalPage}
+                    onSelect={pickTheme}
+                    onClose={() => setShowThemeModal(false)}
+                    s3={s3}
+                    sessionId={sessionId}
+                />
             )}
             {showTitleModal && (
                 <TitleModal
@@ -1087,7 +1113,7 @@ export default function EditorPage(props) {
                         if (next.length === 0) {
                             next.push({
                                 templateId: 3,
-                                theme: { mode: "dynamic", color: null },
+                                theme: { mode: "dynamic", color: null, image: null },
                                 assignedImages: [...uploaded],
                                 edits: new Array(uploaded.length).fill(null),
                             });

--- a/src/components/ThemeModal.js
+++ b/src/components/ThemeModal.js
@@ -1,8 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Layer, Text } from 'grommet';
 import { themeGroups } from '../templates/predefinedThemes';
 
-export default function ThemeModal({ onSelect, onClose, pageIdx }) {
+// base ImageKit URL for transforming uploaded backgrounds
+const IK_URL_ENDPOINT = process.env.REACT_APP_IMAGEKIT_URL_ENDPOINT || "";
+
+// helper to build an ImageKit resize URL with cache-busting
+const getResizedUrl = (key, width = 1200) =>
+    `${IK_URL_ENDPOINT}/${encodeURI(key)}?tr=w-${width},fo-face&v=${Date.now()}`;
+
+export default function ThemeModal({ onSelect, onClose, pageIdx, s3, sessionId }) {
+    const [uploading, setUploading] = useState(false);
+
+    const handleImageUpload = async (e) => {
+        const file = e.target.files && e.target.files[0];
+        if (!file || !s3 || !sessionId) return;
+
+        const key = `${sessionId}/${Date.now()}_${file.name}`;
+        try {
+            setUploading(true);
+            await s3
+                .upload({ Key: key, Body: file, ContentType: file.type })
+                .promise();
+            const url = getResizedUrl(key, 1200);
+            onSelect(pageIdx, { mode: 'image', image: url });
+        } catch (err) {
+            console.error('background upload error', err);
+        } finally {
+            setUploading(false);
+            e.target.value = '';
+        }
+    };
+
     return (
         <Layer
             position="center"
@@ -11,6 +40,16 @@ export default function ThemeModal({ onSelect, onClose, pageIdx }) {
             onClickOutside={onClose}
         >
             <Box pad="small" gap="medium" width="medium" style={{ maxWidth: '90vw', overflowY: 'auto', maxHeight: '90vh' }}>
+                <Box>
+                    <Text weight="bold">Custom Image</Text>
+                    <Box pad={{ vertical: 'xsmall' }}>
+                        {uploading ? (
+                            <Text size="small">Uploading...</Text>
+                        ) : (
+                            <input type="file" accept="image/*" onChange={handleImageUpload} />
+                        )}
+                    </Box>
+                </Box>
                 {themeGroups.map(group => (
                     <Box key={group.name}>
                         <Text weight="bold">{group.name}</Text>


### PR DESCRIPTION
## Summary
- upload background images to S3 and generate ImageKit URLs in the theme modal
- pass session context to the theme modal so backgrounds persist

## Testing
- `CI=true yarn test --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c185852a8c83239e7253984e56109f